### PR TITLE
Configure VCR to ignore the submission of coverage results

### DIFF
--- a/lib/code_climate/test_reporter.rb
+++ b/lib/code_climate/test_reporter.rb
@@ -8,6 +8,10 @@ module CodeClimate
         ::SimpleCov.add_filter 'vendor'
         ::SimpleCov.formatter = Formatter
         ::SimpleCov.start("test_frameworks")
+        
+        if defined?(VCR)
+          VCR.configure { |c| c.ignore_hosts "codeclimate.com" }
+        end
       else
         puts("Not reporting to Code Climate because ENV['CODECLIMATE_REPO_TOKEN'] is not set.")
       end


### PR DESCRIPTION
Without this, we get:

```
Coverage = 81.0%.Sending report to https://codeclimate.com... 
Code Climate encountered an exception: VCR::Errors::UnhandledHTTPRequestError


================================================================================
An HTTP request has been made that VCR does not know how to handle:
  POST https://codeclimate.com/test_reports

There is currently no cassette in use. There are a few ways
you can configure VCR to handle this request:

  * If you're surprised VCR is raising this error
    and want insight about how VCR attempted to handle the request,
    you can use the debug_logger configuration option to log more details [1].
  * If you want VCR to record this request and play it back during future test
    runs, you should wrap your test (or this portion of your test) in a
    `VCR.use_cassette` block [2].
  * If you only want VCR to handle requests made while a cassette is in use,
    configure `allow_http_connections_when_no_cassette = true`. VCR will
    ignore this request since it is made when there is no cassette [3].
  * If you want VCR to ignore this request (and others like it), you can
    set an `ignore_request` callback [4].

[1] https://www.relishapp.com/vcr/vcr/v/2-5-0/docs/configuration/debug-logging
[2] https://www.relishapp.com/vcr/vcr/v/2-5-0/docs/getting-started
[3] https://www.relishapp.com/vcr/vcr/v/2-5-0/docs/configuration/allow-http-connections-when-no-cassette
[4] https://www.relishapp.com/vcr/vcr/v/2-5-0/docs/configuration/ignore-request
================================================================================
```
