### PR TITLE
Configure FakeWeb to allow submission of coverage results.

### DIFF
--- a/lib/code_climate/test_reporter.rb
+++ b/lib/code_climate/test_reporter.rb
@@ -8,6 +8,10 @@ module CodeClimate
         ::SimpleCov.add_filter 'vendor'
         ::SimpleCov.formatter = Formatter
         ::SimpleCov.start("test_frameworks")
+
+        if defined?(FakeWeb)
+          FakeWeb.allow_net_connect = %r[^https?://codeclimate\.com]
+        end
       else
         puts("Not reporting to Code Climate because ENV['CODECLIMATE_REPO_TOKEN'] is not set.")
       end


### PR DESCRIPTION
FakeWeb's `allow_net_connect = false` option is often used to prevent tests from contacting outside resources. Submitting code metrics to CodeClimate represents an special case where it would be useful to bypass this behavior and allow an external connection.

Without the code below, the test reporter generates a `FakeWeb::NetConnectNotAllowedError` exception.

I placed the code for this option in the same spot of `test_reporter.rb` as proposed by the author of https://github.com/codeclimate/ruby-test-reporter/pull/2  for consistency.
