### PR TITLE
[#7] Convert to Float before rounding; avoid a segfault

### DIFF
--- a/lib/code_climate/test_reporter/formatter.rb
+++ b/lib/code_climate/test_reporter/formatter.rb
@@ -9,7 +9,7 @@ module CodeClimate
   module TestReporter
     class Formatter
       def format(result)
-        print "Coverage = #{result.covered_percent.round(2)}%. "
+        print "Coverage = #{round(result.covered_percent, 2)}%. "
 
         payload = to_payload(result)
         if tddium? || ENV["TO_FILE"]
@@ -45,8 +45,8 @@ module CodeClimate
             name:             short_filename(file.filename),
             blob_id:          calculate_blob_id(file.filename),
             coverage:         file.coverage.to_json,
-            covered_percent:  file.covered_percent.round(2),
-            covered_strength: file.covered_strength.round(2),
+            covered_percent:  round(file.covered_percent, 2),
+            covered_strength: round(file.covered_strength, 2),
             line_counts: {
               total:    file.lines.count,
               covered:  file.covered_lines.count,
@@ -59,8 +59,8 @@ module CodeClimate
           repo_token:       ENV["CODECLIMATE_REPO_TOKEN"],
           source_files:     source_files,
           run_at:           result.created_at,
-          covered_percent:  result.covered_percent.round(2),
-          covered_strength: result.covered_strength.round(2),
+          covered_percent:  round(result.covered_percent, 2),
+          covered_strength: round(result.covered_strength, 2),
           line_counts:      totals,
           partial:          partial?,
           git: {
@@ -149,7 +149,7 @@ module CodeClimate
       def compute_branch(payload)
         git_branch = payload[:git][:branch]
         ci_branch = payload[:ci_service][:branch]
-        
+
         if ci_branch.to_s.strip.size > 0
           ci_branch.sub(/^origin\//, "")
         elsif git_branch.to_s.strip.size > 0 && !git_branch.to_s.strip.start_with?("(")
@@ -157,6 +157,12 @@ module CodeClimate
         else
           "master"
         end
+      end
+
+      # Convert to Float before rounding.
+      # Fixes [#7] possible segmentation fault when calling #round on a Rational
+      def round(numeric, precision)
+        Float(numeric).round(precision)
       end
     end
   end


### PR DESCRIPTION
For a covered percent of the Rational `800/22` see #7

``` ruby
(800/22).round(2)  #=> segfault
Float(800/22).round(2) #=> 36.36
```

Found it by reading the stacktrace and using a debugger

``` sh
Coverage = 67.5%.projekt/.rvm/gems/ruby-1.9.3-p448@projekt/gems/codeclimate-test-reporter-0.0.9/lib/code_climate/test_reporter/formatter.rb:49: [BUG] Segmentation fault
ruby 1.9.3p448 (2013-06-27 revision 41675) [x86_64-darwin12.4.0]

-- Control frame information -----------------------------------------------
c:0013 p:---- s:0056 b:0056 l:000055 d:000055 CFUNC  :round
c:0012 p:0198 s:0052 b:0043 l:000034 d:000042 BLOCK  projekt/.rvm/gems/ruby-1.9.3-p448@projekt/gems/codeclimate-test-reporter-0.0.9/lib/code_climate/test_reporter/forma
c:0011 p:---- s:0040 b:0040 l:000039 d:000039 FINISH
c:0010 p:---- s:0038 b:0038 l:000037 d:000037 CFUNC  :map
c:0009 p:0037 s:0035 b:0035 l:000034 d:000034 METHOD projekt/.rvm/gems/ruby-1.9.3-p448@projekt/gems/codeclimate-test-reporter-0.0.9/lib/code_climate/test_reporter/forma
c:0008 p:0046 s:0029 b:0029 l:000028 d:000028 METHOD projekt/.rvm/gems/ruby-1.9.3-p448@projekt/gems/codeclimate-test-reporter-0.0.9/lib/code_climate/test_reporter/forma
c:0007 p:0030 s:0020 b:0020 l:000019 d:000019 METHOD projekt/.rvm/gems/ruby-1.9.3-p448@projekt/gems/simplecov-0.7.1/lib/simplecov/result.rb:91
c:0006 p:0021 s:0017 b:0017 l:0017b0 d:000016 BLOCK  projekt/.rvm/gems/ruby-1.9.3-p448@projekt/gems/simplecov-0.7.1/lib/simplecov/configuration.rb:133
c:0005 p:---- s:0015 b:0015 l:000014 d:000014 FINISH
c:0004 p:---- s:0013 b:0013 l:000012 d:000012 CFUNC  :call
c:0003 p:0070 s:0010 b:0010 l:001a70 d:000009 BLOCK  projekt/.rvm/gems/ruby-1.9.3-p448@projekt/gems/simplecov-0.7.1/lib/simplecov/defaults.rb:52
c:0002 p:---- s:0004 b:0004 l:000003 d:000003 FINISH
c:0001 p:0000 s:0002 b:0002 l:000008 d:000008 TOP   

-- Ruby level backtrace information ----------------------------------------
projekt/.rvm/gems/ruby-1.9.3-p448@projekt/gems/simplecov-0.7.1/lib/simplecov/defaults.rb:52:in `block in <top (required)>'
projekt/.rvm/gems/ruby-1.9.3-p448@projekt/gems/simplecov-0.7.1/lib/simplecov/defaults.rb:52:in `call'
projekt/.rvm/gems/ruby-1.9.3-p448@projekt/gems/simplecov-0.7.1/lib/simplecov/configuration.rb:133:in `block in at_exit'
projekt/.rvm/gems/ruby-1.9.3-p448@projekt/gems/simplecov-0.7.1/lib/simplecov/result.rb:91:in `format!'
projekt/.rvm/gems/ruby-1.9.3-p448@projekt/gems/codeclimate-test-reporter-0.0.9/lib/code_climate/test_reporter/formatter.rb:14:in `format'
projekt/.rvm/gems/ruby-1.9.3-p448@projekt/gems/codeclimate-test-reporter-0.0.9/lib/code_climate/test_reporter/formatter.rb:39:in `to_payload'
projekt/.rvm/gems/ruby-1.9.3-p448@projekt/gems/codeclimate-test-reporter-0.0.9/lib/code_climate/test_reporter/formatter.rb:39:in `map'
projekt/.rvm/gems/ruby-1.9.3-p448@projekt/gems/codeclimate-test-reporter-0.0.9/lib/code_climate/test_reporter/formatter.rb:49:in `block in to_payload'
projekt/.rvm/gems/ruby-1.9.3-p448@projekt/gems/codeclimate-test-reporter-0.0.9/lib/code_climate/test_reporter/formatter.rb:49:in `round'
``
```
