### PR TITLE
Explicitly require logger in Configuration

### DIFF
--- a/lib/code_climate/test_reporter/configuration.rb
+++ b/lib/code_climate/test_reporter/configuration.rb
@@ -1,3 +1,5 @@
+require 'logger'
+
 module CodeClimate
   module TestReporter
     @@configuration = nil


### PR DESCRIPTION
We need an explicit require of logger in configuration to make sure Logger is defined. It worked for me fine locally without the require, but not when it was added to the CI server.
