### PR TITLE
Added path_prefix to configuration

### DIFF
--- a/lib/code_climate/test_reporter/configuration.rb
+++ b/lib/code_climate/test_reporter/configuration.rb
@@ -19,7 +19,7 @@ module CodeClimate
     end
 
     class Configuration
-      attr_accessor :branch, :logger, :profile
+      attr_accessor :branch, :logger, :profile, :path_prefix
 
       def logger
         @logger ||= default_logger

--- a/lib/code_climate/test_reporter/formatter.rb
+++ b/lib/code_climate/test_reporter/formatter.rb
@@ -84,7 +84,8 @@ module CodeClimate
 
       def short_filename(filename)
         return filename unless ::SimpleCov.root
-        filename.gsub(::SimpleCov.root, '.').gsub(/^\.\//, '')
+        filename = filename.gsub(::SimpleCov.root, '.').gsub(/^\.\//, '')
+        apply_prefix filename
       end
 
       def tddium?
@@ -98,6 +99,12 @@ module CodeClimate
       end
 
       private
+
+      def apply_prefix filename
+        prefix = CodeClimate::TestReporter.configuration.path_prefix
+        return filename if prefix.nil?
+        "#{prefix}/#{filename}"
+      end
 
       def ci_service_data
         @ci_service_data ||= Ci.service_data

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -13,6 +13,7 @@ module CodeClimate::TestReporter
         expect(CodeClimate::TestReporter.configuration.logger).to be_instance_of Logger
         expect(CodeClimate::TestReporter.configuration.logger.level).to eq Logger::INFO
         expect(CodeClimate::TestReporter.configuration.profile).to eq('test_frameworks')
+        expect(CodeClimate::TestReporter.configuration.path_prefix).to be_nil
       end
     end
 
@@ -46,6 +47,19 @@ module CodeClimate::TestReporter
         end
 
         expect(CodeClimate::TestReporter.configuration.profile).to eq('custom')
+      end
+
+      it 'stores path prefix' do
+        CodeClimate::TestReporter.configure do |config|
+          config.path_prefix = 'custom'
+        end
+
+        expect(CodeClimate::TestReporter.configuration.path_prefix).to eq('custom')
+
+        CodeClimate::TestReporter.configure do |config|
+          config.path_prefix = nil
+        end
+
       end
     end
   end

--- a/spec/lib/formatter_spec.rb
+++ b/spec/lib/formatter_spec.rb
@@ -98,4 +98,22 @@ module CodeClimate::TestReporter
       app.http_user_agent.should include("v#{CodeClimate::TestReporter::VERSION}")
     end
   end
+
+  describe '#short_filename' do
+    it 'should return the filename of the file relative to the SimpleCov root' do
+      CodeClimate::TestReporter::Formatter.new.short_filename('file1').should == 'file1'
+      CodeClimate::TestReporter::Formatter.new.short_filename("#{::SimpleCov.root}/file1").should == 'file1'
+    end
+
+    it 'should include the path prefix if set' do
+      CodeClimate::TestReporter.configure do |config|
+        config.path_prefix = 'custom'
+      end
+      CodeClimate::TestReporter::Formatter.new.short_filename('file1').should == 'custom/file1'
+      CodeClimate::TestReporter::Formatter.new.short_filename("#{::SimpleCov.root}/file1").should == 'custom/file1'
+      CodeClimate::TestReporter.configure do |config|
+        config.path_prefix = nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Following an email conversation with @noahd1, I believe these are the changes needed for code coverage reporting to work for applications that live in a subfolder.
