### PR TITLE
Adds the ability to disable gzip compression

### DIFF
--- a/lib/code_climate/test_reporter/client.rb
+++ b/lib/code_climate/test_reporter/client.rb
@@ -46,15 +46,20 @@ module CodeClimate
         end
       end
 
-      def post_results(result)
+      def post_results(result, options = { :gzip => true })
         uri = URI.parse("#{host}/test_reports")
         http = http_client(uri)
 
         request = Net::HTTP::Post.new(uri.path)
         request["User-Agent"] = USER_AGENT
         request["Content-Type"] = "application/json"
-        request["Content-Encoding"] = "gzip"
-        request.body = compress(result.to_json)
+
+        if options[:gzip]
+          request["Content-Encoding"] = "gzip"
+          request.body = compress(result.to_json)
+        else
+          request.body = result.to_json
+        end
 
         response = http.request(request)
 

--- a/lib/code_climate/test_reporter/formatter.rb
+++ b/lib/code_climate/test_reporter/formatter.rb
@@ -10,7 +10,7 @@ require "code_climate/test_reporter/payload_validator"
 module CodeClimate
   module TestReporter
     class Formatter
-      def format(result)
+      def format(result, options = { :gzip_request => true })
         print "Coverage = #{round(result.covered_percent, 2)}%. "
 
         payload = to_payload(result)
@@ -22,7 +22,7 @@ module CodeClimate
         else
           client = Client.new
           print "Sending report to #{client.host} for branch #{Git.branch_from_git_or_ci}... "
-          client.post_results(payload)
+          client.post_results(payload, { :gzip => options[:gzip_request] })
         end
 
         puts "done."


### PR DESCRIPTION
The project that I’m on is experiencing a 500 error when submitting
results to CodeClimate. After contacting support, it was suggested that
we try disabling gzip compression, because the decompression step was
the cause of the failure on the server side.
