### PR TITLE
Adds the ability to disable gzip compression

### DIFF
--- a/lib/code_climate/test_reporter/client.rb
+++ b/lib/code_climate/test_reporter/client.rb
@@ -53,8 +53,13 @@ module CodeClimate
         request = Net::HTTP::Post.new(uri.path)
         request["User-Agent"] = USER_AGENT
         request["Content-Type"] = "application/json"
-        request["Content-Encoding"] = "gzip"
-        request.body = compress(result.to_json)
+
+        if CodeClimate::TestReporter.configuration.gzip_request
+          request["Content-Encoding"] = "gzip"
+          request.body = compress(result.to_json)
+        else
+          request.body = result.to_json
+        end
 
         response = http.request(request)
 

--- a/lib/code_climate/test_reporter/configuration.rb
+++ b/lib/code_climate/test_reporter/configuration.rb
@@ -19,7 +19,11 @@ module CodeClimate
     end
 
     class Configuration
-      attr_accessor :branch, :logger, :profile, :path_prefix
+      attr_accessor :branch, :logger, :profile, :path_prefix, :gzip_request
+
+      def initialize
+        @gzip_request = true
+      end
 
       def logger
         @logger ||= default_logger


### PR DESCRIPTION
The project that I’m on is experiencing a 500 error when submitting
results to CodeClimate. After contacting support, it was suggested that
we try disabling gzip compression, because the decompression step was
the cause of the failure on the server side.
