### PR TITLE
Do not crash setting TestReporter::Formatter as a SimpleCov formatter

### DIFF
--- a/lib/code_climate/test_reporter.rb
+++ b/lib/code_climate/test_reporter.rb
@@ -15,23 +15,27 @@ module CodeClimate
     end
 
     def self.environment_variable_set?
-      environment_variable_set = !!ENV["CODECLIMATE_REPO_TOKEN"]
-      unless environment_variable_set
+      return @environment_variable_set if defined?(@environment_variable_set)
+
+      @environment_variable_set = !!ENV["CODECLIMATE_REPO_TOKEN"]
+      unless @environment_variable_set
         logger.info("Not reporting to Code Climate because ENV['CODECLIMATE_REPO_TOKEN'] is not set.")
       end
 
-      environment_variable_set
+      @environment_variable_set
     end
 
     def self.run_on_current_branch?
-      return true if configured_branch.nil?
+      return @run_on_current_branch if defined?(@run_on_current_branch)
 
-      run_on_current_branch = !!(current_branch =~ /#{configured_branch}/i)
-      unless run_on_current_branch
+      @run_on_current_branch = true if configured_branch.nil?
+      @run_on_current_branch ||= !!(current_branch =~ /#{configured_branch}/i)
+
+      unless @run_on_current_branch
         logger.info("Not reporting to Code Climate because #{configured_branch} is set as the reporting branch.")
       end
 
-      run_on_current_branch
+      @run_on_current_branch
     end
 
     def self.configured_branch

--- a/lib/code_climate/test_reporter/formatter.rb
+++ b/lib/code_climate/test_reporter/formatter.rb
@@ -11,6 +11,8 @@ module CodeClimate
   module TestReporter
     class Formatter
       def format(result)
+        return true unless CodeClimate::TestReporter.run?
+
         print "Coverage = #{round(result.covered_percent, 2)}%. "
 
         payload = to_payload(result)

--- a/spec/lib/test_reporter_spec.rb
+++ b/spec/lib/test_reporter_spec.rb
@@ -1,33 +1,35 @@
 require 'spec_helper'
 
 describe CodeClimate::TestReporter do
+  let(:reporter) { CodeClimate::TestReporter.dup }
 
   describe '.run_on_current_branch?' do
     it 'returns true if there is no branch configured' do
-      allow(CodeClimate::TestReporter).to receive(:configured_branch).and_return(nil)
-      expect(CodeClimate::TestReporter.run_on_current_branch?).to be_true
+      allow(reporter).to receive(:configured_branch).and_return(nil)
+      expect(reporter).to be_run_on_current_branch
     end
 
     it 'returns true if the current branch matches the configured branch' do
-      allow(CodeClimate::TestReporter).to receive(:current_branch).and_return("master\n")
-      allow(CodeClimate::TestReporter).to receive(:configured_branch).and_return(:master)
+      allow(reporter).to receive(:current_branch).and_return("master\n")
+      allow(reporter).to receive(:configured_branch).and_return(:master)
 
-      expect(CodeClimate::TestReporter.run_on_current_branch?).to be_true
+      expect(reporter).to be_run_on_current_branch
     end
 
     it 'returns false if the current branch and configured branch dont match' do
-      allow(CodeClimate::TestReporter).to receive(:current_branch).and_return("some-branch")
-      allow(CodeClimate::TestReporter).to receive(:configured_branch).and_return(:master)
+      allow(reporter).to receive(:current_branch).and_return("some-branch")
+      allow(reporter).to receive(:configured_branch).and_return(:master)
 
-      expect(CodeClimate::TestReporter.run_on_current_branch?).to be_false
+      expect(reporter).to_not be_run_on_current_branch
     end
 
     it 'logs a message if false' do
       expect_any_instance_of(Logger).to receive(:info)
-      allow(CodeClimate::TestReporter).to receive(:current_branch).and_return("another-branch")
-      allow(CodeClimate::TestReporter).to receive(:configured_branch).and_return(:master)
 
-      CodeClimate::TestReporter.run_on_current_branch?
+      allow(reporter).to receive(:current_branch).and_return("another-branch")
+      allow(reporter).to receive(:configured_branch).and_return(:master)
+
+      reporter.run_on_current_branch?
     end
   end
 


### PR DESCRIPTION
This allows people to set the Code Climate report formatter as a SimpleCov formatter. It memoizes the run checks to not duplicate log messages when we're checking `run?` twice.

Fixes #44, #45

/cc @brynary 
