### PR TITLE
Add Drone to CI Service Data.

### DIFF
--- a/lib/code_climate/test_reporter/ci.rb
+++ b/lib/code_climate/test_reporter/ci.rb
@@ -45,6 +45,15 @@ module CodeClimate
             branch:           ENV['WERCKER_GIT_BRANCH'],
             commit_sha:       ENV['WERCKER_GIT_COMMIT']
           }
+        elsif ENV['CI_NAME'] =~ /DRONE/i
+          {
+            name:             "drone",
+            build_identifier: ENV['CI_BUILD_NUMBER'],
+            build_url:        ENV['CI_BUILD_URL'],
+            branch:           ENV['CI_BRANCH'],
+            commit_sha:       ENV['CI_BUILD_NUMBER'],
+            pull_request:     ENV['CI_PULL_REQUEST']
+          }
         elsif ENV['CI_NAME'] =~ /codeship/i
           {
             name:             "codeship",


### PR DESCRIPTION
This adds support for [Drone](https://github.com/drone/drone).  The Drone test coverage env vars are not documented, but [exist here](https://github.com/drone/drone/blob/master/pkg/build/build.go#L496-L502).

![screen shot 2014-08-14 at 7 59 04 pm](https://cloud.githubusercontent.com/assets/90807/3928706/04bb51da-240f-11e4-8366-9de8e2e00e01.png)
