### PR TITLE
Adding the CodeClimate coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # codeclimate-test-reporter
 
 [![Code Climate](https://codeclimate.com/github/codeclimate/ruby-test-reporter.png)](https://codeclimate.com/github/codeclimate/ruby-test-reporter)
+[![Test Coverage](https://codeclimate.com/github/codeclimate/ruby-test-reporter/badges/coverage.svg)](https://codeclimate.com/github/codeclimate/ruby-test-reporter)
 
 Collects test coverage data from your Ruby test suite and sends it to Code
 Climate's hosted, automated code review service. Based on SimpleCov.


### PR DESCRIPTION
Even though the coverage is unknown, people should know what they're getting into when grabbing an open source project. Unknown coverage is important.
![selfie-0](http://i.imgur.com/5vv2zfw.png)
