### PR TITLE
Added ruby version >= 1.9 to gemspec

### DIFF
--- a/codeclimate-test-reporter.gemspec
+++ b/codeclimate-test-reporter.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
+  
+  spec.required_ruby_version = ">= 1.9"
 
   spec.add_dependency "simplecov", ">= 0.7.1", "< 1.0.0"
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
Fix for #26.

SimpleCov technically does support ruby 1.8.7, but code climate does not (because it uses 1.9-style hash syntax). At least by adding this to the gemspec it's explicit to anyone wanting to use the gem (rather than them trying it and seeing errors)
