### PR TITLE
Git commands executes in root directory

### DIFF
--- a/lib/code_climate/test_reporter/git.rb
+++ b/lib/code_climate/test_reporter/git.rb
@@ -5,7 +5,7 @@ module CodeClimate
       class << self
         def info
           {
-            head:         `git log -1 --pretty=format:'%H'`,
+            head:         head,
             committed_at: committed_at,
             branch:       branch_from_git,
           }
@@ -31,15 +31,28 @@ module CodeClimate
 
         private
 
+        def head
+          git("log -1 --pretty=format:'%H'")
+        end
+
         def committed_at
-          committed_at = `git log -1 --pretty=format:%ct`
+          committed_at = git('log -1 --pretty=format:%ct')
           committed_at.to_i.zero? ? nil : committed_at.to_i
         end
 
         def branch_from_git
-          `git rev-parse --abbrev-ref HEAD`.chomp
+          git('rev-parse --abbrev-ref HEAD').chomp
+        end
+
+        def git(command)
+          `git --git-dir=#{git_dir}/.git #{command}`
+        end
+
+        def git_dir
+          defined?(Rails) ? Rails.root : '.'
         end
       end
     end
   end
 end
+


### PR DESCRIPTION
Hi, i found very strange bug. I'm using Rails 4.2.0 and Travis-CI with Docker builds.

And when codeclimate tests reporter try to gather some git data, its fails with:

```
Coverage report generated for RSpec to /home/travis/build/Strech/terminal/coverage. 1668 / 1700 LOC (98.12%) covered.
Coverage = 98.12%. fatal: Not a git repository (or any of the parent directories): .git
fatal: Not a git repository (or any of the parent directories): .git
fatal: Not a git repository (or any of the parent directories): .git
```

I'm start digg in, and found, that codeclimate test reporter, on a gather moment have `pwd` in `/tmp` directory

```
Coverage report generated for RSpec to /home/travis/build/Strech/terminal/coverage. 1668 / 1700 LOC (98.12%) covered.
Coverage = 98.12%. fatal: Not a git repository (or any of the parent directories): .git
fatal: Not a git repository (or any of the parent directories): .git
fatal: Not a git repository (or any of the parent directories): .git
"PWD = /tmp\n" <------------------------------------
"root of Rails = /home/travis/build/Strech/terminal" <------------------------------------
```

This request try to change git execution directory on Rails root, or use current, as it was before.
