### PR TITLE
Eliminate method redefinition warnings

### DIFF
--- a/lib/code_climate/test_reporter/configuration.rb
+++ b/lib/code_climate/test_reporter/configuration.rb
@@ -19,7 +19,9 @@ module CodeClimate
     end
 
     class Configuration
-      attr_accessor :branch, :logger, :profile, :path_prefix, :gzip_request, :git_dir
+      attr_accessor :branch, :path_prefix, :gzip_request, :git_dir
+
+      attr_writer :logger, :profile
 
       def initialize
         @gzip_request = true


### PR DESCRIPTION
This gets rid of the following warnings:
```
codeclimate-test-reporter-0.4.5/lib/code_climate/test_reporter/configuration.rb:28:
warning: method redefined; discarding old logger
codeclimate-test-reporter-0.4.5/lib/code_climate/test_reporter/configuration.rb:32:
warning: method redefined; discarding old profile
```