### PR TITLE
Quote git_dir when used in git command execution

### DIFF
--- a/lib/code_climate/test_reporter/git.rb
+++ b/lib/code_climate/test_reporter/git.rb
@@ -45,7 +45,7 @@ module CodeClimate
         end
 
         def git(command)
-          `git --git-dir=#{git_dir}/.git #{command}`
+          `git --git-dir="#{git_dir}"/.git #{command}`
         end
 
         def git_dir

--- a/lib/code_climate/test_reporter/git.rb
+++ b/lib/code_climate/test_reporter/git.rb
@@ -45,7 +45,7 @@ module CodeClimate
         end
 
         def git(command)
-          `git --git-dir="#{git_dir}"/.git #{command}`
+          `git --git-dir="#{git_dir}/.git" #{command}`
         end
 
         def git_dir

--- a/spec/lib/git_spec.rb
+++ b/spec/lib/git_spec.rb
@@ -14,6 +14,17 @@ module CodeClimate::TestReporter
       end
     end
 
+    describe 'git' do
+      it 'should quote the git repository directory' do
+        path = '/path/to/foo bar'
+
+        allow(CodeClimate::TestReporter.configuration).to receive(:git_dir).and_return path
+        expect(Git).to receive(:`).once.with "git --git-dir=\"#{path}/.git\" help"
+
+        Git.send :git, 'help'
+        end
+    end
+
     describe 'branch_from_git_or_ci' do
       it 'returns the branch from ci' do
         allow(Ci).to receive(:service_data).and_return({branch: 'ci-branch'})


### PR DESCRIPTION
This prevents exceptions (and possibly worse) when attempting to execute git against repositories whose path contains a space.
Note that this doesn't try to protect against stranger cases, like directory names that contain double-quotes, but I'm not familiar with all the special characters that would need to be escaped here.