### PR TITLE
Fixed bug preventing non-rails apps to fail to transfer coverage to code climate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+*.sw[^f]

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,3 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
-*.sw[^f]

--- a/lib/code_climate/test_reporter/git.rb
+++ b/lib/code_climate/test_reporter/git.rb
@@ -58,7 +58,7 @@ module CodeClimate
         end
 
         def rails_git_dir_present?
-          defined?(Rails) && !Rails.root.nil? &&
+          const_defined?(:Rails) && Rails.respond_to?(:root) && !Rails.root.nil? &&
             File.directory?(File.expand_path('.git', Rails.root))
         end
       end

--- a/spec/lib/git_spec.rb
+++ b/spec/lib/git_spec.rb
@@ -41,7 +41,7 @@ module CodeClimate::TestReporter
           expect(Git).to receive(:configured_git_dir).once.and_return(nil)
         end
 
-        it 'will not rails root if constant Rails is defined but does not respond to root' do
+        it 'will not call method "root" (a 3rd time) if constant Rails is defined but does not respond to root' do
           expect(Git).to receive(:configured_git_dir).once.and_return(nil)
           expect(Rails).to receive(:root).twice.and_return('/path')
         end


### PR DESCRIPTION
After setting up code climate in my non-rails app I noticed that I was not transmitting the coverage report up to codeclimate due to some bad/wrong code that relied on `defined?` and `Rails.root` incorrectly.

The "fix" for the `Rails.root` support also didn't have tests.

So, I added a fix to support non rails and wrote tests to make sure that we wouldn't have trouble going forward.

Here is the original exception:

    Coverage = 100.0%. Code Climate encountered an exception: NoMethodError
    undefined method `root' for Rails:Module
    /home/ubuntu/census/vendor/bundle/ruby/1.9.1/gems/codeclimate-test-reporter-0.4.6/lib/code_climate/test_reporter/git.rb:61:in `rails_git_dir_present?'
    /home/ubuntu/census/vendor/bundle/ruby/1.9.1/gems/codeclimate-test-reporter-0.4.6/lib/code_climate/test_reporter/git.rb:53:in `git_dir'
    /home/ubuntu/census/vendor/bundle/ruby/1.9.1/gems/codeclimate-test-reporter-0.4.6/lib/code_climate/test_reporter/git.rb:48:in `git'
    /home/ubuntu/census/vendor/bundle/ruby/1.9.1/gems/codeclimate-test-reporter-0.4.6/lib/code_climate/test_reporter/git.rb:35:in `head'
    /home/ubuntu/census/vendor/bundle/ruby/1.9.1/gems/codeclimate-test-reporter-0.4.6/lib/code_climate/test_reporter/git.rb:8:in `info'
    /home/ubuntu/census/vendor/bundle/ruby/1.9.1/gems/codeclimate-test-reporter-0.4.6/lib/code_climate/test_reporter/formatter.rb:72:in `to_payload'
    /home/ubuntu/census/vendor/bundle/ruby/1.9.1/gems/codeclimate-test-reporter-0.4.6/lib/code_climate/test_reporter/formatter.rb:20:in `format'
    /home/ubuntu/census/vendor/bundle/ruby/1.9.1/gems/simplecov-0.9.1/lib/simplecov/result.rb:46:in `format!'
    /home/ubuntu/census/vendor/bundle/ruby/1.9.1/gems/simplecov-0.9.1/lib/simplecov/configuration.rb:158:in `block in at_exit'
    /home/ubuntu/census/vendor/bundle/ruby/1.9.1/gems/simplecov-0.9.1/lib/simplecov/defaults.rb:54:in `call'
    /home/ubuntu/census/vendor/bundle/ruby/1.9.1/gems/simplecov-0.9.1/lib/simplecov/defaults.rb:54:in `block in <top (required)>'



