### PR TITLE
Add note about parallelization CircleCI to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ require 'codeclimate-test-reporter'
 CodeClimate::TestReporter::Formatter.new.format(SimpleCov.result)
 ```
 
+Note this [doesn't currently work](https://circleci.com/docs/code-coverage#code-climate) with CircleCI's parallelization. If you want this please help by letting them know.
+
 ## Help! Your gem is raising a ...
 
 ### VCR::Errors::UnhandledHTTPRequestError


### PR DESCRIPTION
It doesn't currently work, but they are asking for people to tell them if they want it.

Add a note to the readme about this to save people from trying in vain.

https://circleci.com/docs/code-coverage#code-climate

> Code Climate does not currently support CircleCI's parallelization. Contact us if you'd like to use this.