### PR TITLE
cleanup + tests

### DIFF
--- a/bin/cc-tddium-post-worker
+++ b/bin/cc-tddium-post-worker
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-require 'rubygems'
 require 'codeclimate-test-reporter'
 require 'tmpdir'
 

--- a/codeclimate-test-reporter.gemspec
+++ b/codeclimate-test-reporter.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "artifice"
+  spec.add_development_dependency "webmock"
   spec.add_development_dependency "pry"
 end

--- a/spec/lib/ci_spec.rb
+++ b/spec/lib/ci_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 module CodeClimate::TestReporter
   describe Ci do
-
     describe '.service_data' do
       before :each do
         @env = {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,46 +1,26 @@
-require 'rubygems'
 require 'bundler/setup'
-require 'artifice'
 require 'pry'
 require 'codeclimate-test-reporter'
+require 'webmock/rspec'
 
 ENV['CODECLIMATE_REPO_TOKEN'] = "172754c1bf9a3c698f7770b9fb648f1ebb214425120022d0b2ffc65b97dff531"
 ENV['CODECLIMATE_API_HOST']   = "http://cc.dev"
 
-def inflate(string)
-  reader = Zlib::GzipReader.new(StringIO.new(string))
-  reader.read
+module TestHelper
+  def inflate(string)
+    reader = Zlib::GzipReader.new(StringIO.new(string))
+    reader.read
+  end
+
+  def capture_requests(stub)
+    requests = []
+    stub.to_return { |r| requests << r; {body: "hello"} }
+    requests
+  end
 end
 
-class FakeCodeClimateEndpoint
-  def call(env)
-    @env = env
-    [
-      200,
-      {"Content-Type" => 'text/plain'},
-      ["Received"]
-    ]
-  end
-
-  def path_info
-    @env["PATH_INFO"]
-  end
-
-  def request_body
-    @env["rack.input"].string
-  end
-
-  def content_type
-    @env["CONTENT_TYPE"]
-  end
-
-  def http_content_encoding
-    @env["HTTP_CONTENT_ENCODING"]
-  end
-
-  def http_user_agent
-    @env["HTTP_USER_AGENT"]
-  end
+RSpec.configure do |c|
+  c.include TestHelper
 end
 
 


### PR DESCRIPTION
@calavera 

using webmock since it has the nice sideeffect of blowing up when a request is done by accident
also we no longer need to declare a custom rack endpoint :)

dropping rubygems requires since they are not needed on 1.9+

adding test for untested batch_post_results
