### PR TITLE
merge all reports into 1 before submitting

### DIFF
--- a/lib/code_climate/test_reporter/client.rb
+++ b/lib/code_climate/test_reporter/client.rb
@@ -84,7 +84,7 @@ module CodeClimate
 
             total = coverage.size
             missed, covered = coverage.compact.partition { |l| l == 0 }.map(&:size)
-            old_file["covered_percent"] = covered * 100.0 / (covered + missed)
+            old_file["covered_percent"] = (covered == 0 ? 0.0 : covered * 100.0 / (covered + missed))
             old_file["line_counts"] = {"total" => total, "covered" => covered, "missed" => missed}
           else
             # just use the new value

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -24,26 +24,15 @@ module CodeClimate::TestReporter
     describe "#batch_post_results" do
       let(:uuid) { "my-uuid" }
       let(:token) { ENV["CODECLIMATE_REPO_TOKEN"] }
-      let(:request_start) { "--#{uuid}\r\nContent-Disposition: form-data; name=\"repo_token\"\r\n\r\n#{token}\r\n--#{uuid}\r\nContent-Disposition: form-data; name=\"coverage_reports[0]\"; filename=\"a\"\r\nContent-Type: application/json\r\n\r\n" }
-      let(:request_end) { "\r\n--#{uuid}--\r\n" }
 
-      def remove_boilerplate(response)
-        [request_start, request_end].each do |part|
-          expect(response).to include part
-          response = response.sub(part, "")
-        end
-        response
-      end
-
-      before { expect(SecureRandom).to receive(:uuid).and_return uuid }
       around { |test| Dir.mktmpdir { |dir| Dir.chdir(dir, &test) } }
 
       it "posts a single file" do
-        File.write("a", "Something")
-        requests = capture_requests(stub_request(:post, "http://cc.dev/test_reports/batch"))
+        File.write("a", '{"Some":"Thing"}')
+        requests = capture_requests(stub_request(:post, "http://cc.dev/test_reports"))
         Client.new.batch_post_results(["a"])
 
-        expect(remove_boilerplate(requests.first.body)).to eq "Something"
+        expect(inflate(requests.first.body)).to eq '{"Some":"Thing"}'
       end
 
       it "merges multiple files" do
@@ -64,10 +53,10 @@ module CodeClimate::TestReporter
         }
         File.write("b", b.to_json)
 
-        requests = capture_requests(stub_request(:post, "http://cc.dev/test_reports/batch"))
+        requests = capture_requests(stub_request(:post, "http://cc.dev/test_reports"))
         Client.new.batch_post_results(["a", "b"])
 
-        expect(JSON.load(remove_boilerplate(requests.first.body))).to eq(
+        expect(JSON.load(inflate(requests.first.body))).to eq(
           "source_files"=>[
             {"name"=>"a", "coverage"=>"[null,3,0,null]", "foo"=>"bar", "line_counts"=>{"total"=>4, "covered"=>1, "missed"=>1}, "covered_percent"=>50.0},
             {"name"=>"b", "coverage"=>"[null,1,1,null]", "line_counts"=>{"total"=>4, "covered"=>2, "missed"=>0}, "covered_percent"=>100.0}

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -24,6 +24,16 @@ module CodeClimate::TestReporter
     describe "#batch_post_results" do
       let(:uuid) { "my-uuid" }
       let(:token) { ENV["CODECLIMATE_REPO_TOKEN"] }
+      let(:request_start) { "--#{uuid}\r\nContent-Disposition: form-data; name=\"repo_token\"\r\n\r\n#{token}\r\n--#{uuid}\r\nContent-Disposition: form-data; name=\"coverage_reports[0]\"; filename=\"a\"\r\nContent-Type: application/json\r\n\r\n" }
+      let(:request_end) { "\r\n--#{uuid}--\r\n" }
+
+      def remove_boilerplate(response)
+        [request_start, request_end].each do |part|
+          expect(response).to include part
+          response = response.sub(part, "")
+        end
+        response
+      end
 
       before { expect(SecureRandom).to receive(:uuid).and_return uuid }
       around { |test| Dir.mktmpdir { |dir| Dir.chdir(dir, &test) } }
@@ -33,7 +43,37 @@ module CodeClimate::TestReporter
         requests = capture_requests(stub_request(:post, "http://cc.dev/test_reports/batch"))
         Client.new.batch_post_results(["a"])
 
-        expect(requests.first.body).to eq "--#{uuid}\r\nContent-Disposition: form-data; name=\"repo_token\"\r\n\r\n#{token}\r\n--#{uuid}\r\nContent-Disposition: form-data; name=\"coverage_reports[0]\"; filename=\"a\"\r\nContent-Type: application/json\r\n\r\nSomething\r\n--#{uuid}--\r\n"
+        expect(remove_boilerplate(requests.first.body)).to eq "Something"
+      end
+
+      it "merges multiple files" do
+        a = {
+          "source_files" => [
+            {"name" => "a", "coverage" => "[null,0,0,null]", "foo" => "bar", "line_counts" => {"total" => 4, "covered" => 0, "missed" => 2}}
+          ],
+          "line_counts" => {"total" => 4, "covered" => 0, "missed" => 2}
+        }
+        File.write("a", a.to_json)
+
+        b = {
+          "source_files" => [
+            {"name" => "a", "coverage" => "[null,3,0,null]", "line_counts" => {"total" => 4, "covered" => 1, "missed" => 1}},
+            {"name" => "b", "coverage" => "[null,1,1,null]", "line_counts" => {"total" => 4, "covered" => 2, "missed" => 0}, "covered_percent" => 100.0}
+          ],
+          "line_counts" => {"total" => 8, "covered" => 3, "missed" => 1}
+        }
+        File.write("b", b.to_json)
+
+        requests = capture_requests(stub_request(:post, "http://cc.dev/test_reports/batch"))
+        Client.new.batch_post_results(["a", "b"])
+
+        expect(JSON.load(remove_boilerplate(requests.first.body))).to eq(
+          "source_files"=>[
+            {"name"=>"a", "coverage"=>"[null,3,0,null]", "foo"=>"bar", "line_counts"=>{"total"=>4, "covered"=>1, "missed"=>1}, "covered_percent"=>50.0},
+            {"name"=>"b", "coverage"=>"[null,1,1,null]", "line_counts"=>{"total"=>4, "covered"=>2, "missed"=>0}, "covered_percent"=>100.0}
+          ],
+          "line_counts"=>{"total"=>8, "covered"=>3, "missed"=>1}
+        )
       end
     end
   end


### PR DESCRIPTION
we are using https://travis-ci.org/grosser/forking_test_runner to run our tests -> 200+ coverage reports per server -> unify them before sending or we run into a 413 Request entity too large

this includes my last PR, let's dicuss/merge that first

also needed for [cc-amend](https://github.com/grosser/cc-amend) which combines reports from multiple servers into one
@calavera 