### PR TITLE
set skipped lines coverage into null so that codeclimate will skip them

### DIFF
--- a/lib/code_climate/test_reporter/formatter.rb
+++ b/lib/code_climate/test_reporter/formatter.rb
@@ -47,6 +47,11 @@ module CodeClimate
           totals[:covered]    += file.covered_lines.count
           totals[:missed]     += file.missed_lines.count
 
+          #if skipped line is not covered, its coverage needs to set to nil
+          file.skipped_lines.each do |skipped_line|
+            file.coverage[skipped_line.line_number - 1] = nil
+          end
+
           {
             name:             short_filename(file.filename),
             blob_id:          CalculateBlob.new(file.filename).blob_id,

--- a/spec/lib/formatter_spec.rb
+++ b/spec/lib/formatter_spec.rb
@@ -18,8 +18,9 @@ module CodeClimate::TestReporter
           :lines            => [double, double, double],
           :covered_lines    => [double, double],
           :missed_lines     => [double],
+          :skipped_lines    => [double(:line_number => 5), double(:line_number => 6)],
           :filename         => project_file,
-          :coverage         => [0,3,2,nil],
+          :coverage         => [0,3,2,nil,1,0],
           :covered_percent  => 33.2,
           :covered_strength => 2
         )
@@ -45,7 +46,7 @@ module CodeClimate::TestReporter
             {
               "name" => project_file,
               "blob_id" => "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-              "coverage" => "[0,3,2,null]",
+              "coverage" => "[0,3,2,null,null,null]",
               "covered_percent" => 33.2,
               "covered_strength" => 2.0,
               "line_counts" => {"total"=>3, "covered"=>2, "missed"=>1}


### PR DESCRIPTION
This reporter now supports skip_token, after run rspec command, the calculated percentage is correct. However the coverage array of each file is not correct: coverage of skipped lines is still 0,1 or null. This pull request just set coverage of all skipped lines into null.