### PR TITLE
log message when sending coverage report

### DIFF
--- a/lib/code_climate/test_reporter.rb
+++ b/lib/code_climate/test_reporter.rb
@@ -20,8 +20,8 @@ module CodeClimate
       return @environment_variable_set if defined?(@environment_variable_set)
 
       @environment_variable_set = !!ENV["CODECLIMATE_REPO_TOKEN"]
-      unless @environment_variable_set
-        logger.info("Not reporting to Code Climate because ENV['CODECLIMATE_REPO_TOKEN'] is not set.")
+      if @environment_variable_set
+        logger.info("Reporting coverage data to Code Climate.")
       end
 
       @environment_variable_set


### PR DESCRIPTION
This message isn't very useful to see on every test run so I'd rather 'hide' it at the debug log level or drop the log message completely.

In fact, perhaps it makes more sense to log a message when `CODECLIMATE_REPO_TOKEN` *is* set?

