### PR TITLE
Added Vexor.io to the list of CIs.

### DIFF
--- a/lib/code_climate/test_reporter/ci.rb
+++ b/lib/code_climate/test_reporter/ci.rb
@@ -71,6 +71,15 @@ module CodeClimate
             branch:           env['CI_BRANCH'],
             commit_sha:       env['CI_COMMIT_ID'],
           }
+        elsif env['CI_NAME'] =~ /VEXOR/i
+          {
+            name:             'vexor',
+            build_identifier: env['CI_BUILD_NUMBER'],
+            build_url:        env['CI_BUILD_URL'],
+            branch:           env['CI_BRANCH'],
+            commit_sha:       env['CI_BUILD_SHA'],
+            pull_request:     env['CI_PULL_REQUEST_ID']
+          }
         elsif env['BUILDBOX']
           {
             name:             "buildbox",


### PR DESCRIPTION
Hi! Our clients want to use this gem inside our CI (https://vexor.io), so this commit is supposed to add support for it.