### PR TITLE
Do not format coverage result when exiting forked process

### DIFF
--- a/lib/code_climate/test_reporter.rb
+++ b/lib/code_climate/test_reporter.rb
@@ -3,11 +3,17 @@ module CodeClimate
 
     def self.start
       if run?
+        test_runner_pid = Process.pid
         require "simplecov"
         ::SimpleCov.add_filter 'vendor'
         ::SimpleCov.formatter = Formatter
         ::SimpleCov.start(configuration.profile) do
           skip_token CodeClimate::TestReporter.configuration.skip_token
+        end
+        ::SimpleCov.at_exit do
+          if test_runner_pid == Process.pid
+            ::SimpleCov.result.format!
+          end
         end
       end
     end


### PR DESCRIPTION
Before: Every forked process will attempt to send coverage results
```
cc:analyzer jacob$ CODECLIMATE_REPO_TOKEN=xxx bundle exec rake spec:integration
I, [2015-04-28T10:30:01.530853 #86241]  INFO -- : Reporting coverage data to Code Climate.
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}
Coverage = 13.46%. Coverage = 13.08%. Sending report to https://codeclimate.com for branch jr-disable_language... Sending report to https://codeclimate.com for branch jr-disable_language... Code Climate encountered an exception: RuntimeError
HTTP Error: 401
```

After:
```
cc:analyzer jacob$ CODECLIMATE_REPO_TOKEN=xxx bundle exec rake spec:integration
I, [2015-04-28T10:30:56.158738 #86317]  INFO -- : Reporting coverage data to Code Climate.
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}
.....

Finished in 45.41 seconds
5 examples, 0 failures
Coverage = 64.19%. Sending report to https://codeclimate.com for branch jr-disable_language... Code Climate encountered an exception: RuntimeError
HTTP Error: 401
```