### PR TITLE
Use env vars so that you don't have to push a .git to a repo

### DIFF
--- a/lib/code_climate/test_reporter/git.rb
+++ b/lib/code_climate/test_reporter/git.rb
@@ -5,9 +5,9 @@ module CodeClimate
       class << self
         def info
           {
-            head:         head,
-            committed_at: committed_at,
-            branch:       branch_from_git,
+            head:         ENV['GIT_HEAD'] || head,
+            committed_at: ENV['GIT_COMMITTED_AT'] || committed_at,
+            branch:       ENV['GIT_BRANCH_FROM'] || branch_from_git,
           }
         end
 


### PR DESCRIPTION
Hi -

Over the past couple of months we have been in the processing of migrating to container style deployments. We build docker images and test our code in the container. Because our repo is so large _and_ we want to avoid bloating images (which slow down deployments). We do not push the whole git repo into the image that we are building. This pull request allows an individual to specify the GIT parameters as environmental variables. We would love to see this change in the mainstream codebase.

Paul