### PR TITLE
Don't remove the simplecov root more than once

### DIFF
--- a/lib/code_climate/test_reporter/formatter.rb
+++ b/lib/code_climate/test_reporter/formatter.rb
@@ -39,7 +39,7 @@ module CodeClimate
       # actually private ...
       def short_filename(filename)
         return filename unless ::SimpleCov.root
-        filename = filename.gsub(::SimpleCov.root, ".").gsub(/^\.\//, "")
+        filename = filename.gsub(/^#{::SimpleCov.root}/, ".").gsub(/^\.\//, "")
         apply_prefix filename
       end
 

--- a/spec/lib/formatter_spec.rb
+++ b/spec/lib/formatter_spec.rb
@@ -131,6 +131,10 @@ module CodeClimate::TestReporter
           expect(formatter.send(:short_filename, "#{::SimpleCov.root}/file1")).to eq('custom/file1')
         end
       end
+
+      it "should not strip the subdirectory if it has the same name as the root" do
+        expect(formatter.send(:short_filename, "#{::SimpleCov.root}/#{::SimpleCov.root}/file1")).to eq("#{::SimpleCov.root}/file1")
+      end
     end
   end
 end


### PR DESCRIPTION
If you have a rails app in a directory named `/app`, you will remove too
much. Make sure we're only removing the first instance of it.

@codeclimate/review 