### PR TITLE
Fix Drone CI commit_sha inference

### DIFF
--- a/lib/code_climate/test_reporter/ci.rb
+++ b/lib/code_climate/test_reporter/ci.rb
@@ -60,7 +60,7 @@ module CodeClimate
             build_identifier: env["CI_BUILD_NUMBER"],
             build_url:        env["CI_BUILD_URL"],
             branch:           env["CI_BRANCH"],
-            commit_sha:       env["CI_BUILD_NUMBER"],
+            commit_sha:       env["CI_COMMIT"],
             pull_request:     env["CI_PULL_REQUEST"]
           }
         elsif env["CI_NAME"] =~ /codeship/i


### PR DESCRIPTION
This mapping is misconfigured to use the CI build number for git commit sha, as
reported in https://github.com/codeclimate/python-test-reporter/issues/23.

@codeclimate/review :mag_right: