### PR TITLE
Respect SSL_CERT_FILE environment variable

### DIFF
--- a/lib/code_climate/test_reporter/client.rb
+++ b/lib/code_climate/test_reporter/client.rb
@@ -79,7 +79,7 @@ module CodeClimate
           if uri.scheme == "https"
             http.use_ssl = true
             http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-            http.ca_file = File.expand_path("../../../../config/cacert.pem", __FILE__)
+            http.ca_file = ca_file
             http.verify_depth = 5
           end
           http.open_timeout = CodeClimate::TestReporter.configuration.timeout
@@ -95,6 +95,10 @@ module CodeClimate
         sio.string
       end
 
+      def ca_file
+        ENV["SSL_CERT_FILE"] ||
+          File.expand_path("../../../../config/cacert.pem", __FILE__)
+      end
     end
   end
 end


### PR DESCRIPTION
This is important when you self-host CodeClimate and use your own certificate. The one in the repo is over 3 years old and can't cover all self-signed certificates either.