### PR TITLE
Ability to specify which branch name is sent to Code Climate

### DIFF
--- a/lib/code_climate/test_reporter/ci.rb
+++ b/lib/code_climate/test_reporter/ci.rb
@@ -95,6 +95,11 @@ module CodeClimate
             branch:           env["CI_BUILD_REF_NAME"],
             commit_sha:       env["CI_BUILD_REF"]
           }
+        elsif env["BRANCH"]
+          {
+            name:            "custom-branch",
+            branch:          env["BRANCH"]
+          }
         else
           {}
         end


### PR DESCRIPTION
There is an instance when using a custom CI runner that a given test run will first run a git checkout on the SHA revision instead of the branch name (in the instance when you wish to re-run a test for a given push to a branch, usually due to a stalled/failed test run, and not the current state of the branch). In this scenario, when you checkout the SHA, you enter a detached HEAD state. As such, the `branch_from_git_or_ci` function will use the git branch value, which will always be HEAD. As such, you cannot push values to Code Climate. 

The proposed solution is to be able to define the branch name through ENV. Since we know the branch name at the time of run/re-run, setting this ENV is trivial, but allows for the right branch to be used when pushing our results to CodeClimate. 