### PR TITLE
Lock to earlier version of simplecov

### DIFF
--- a/codeclimate-test-reporter.gemspec
+++ b/codeclimate-test-reporter.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 1.9"
 
-  spec.add_dependency "simplecov", ">= 0.7.1", "< 1.0.0"
+  spec.add_dependency "simplecov", ">= 0.7.1", "< 0.12.0"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
Some later versions of simplecov effectively don't support ruby 1.9.3 due to a
loose json dependency that picks the latest version of `json`:

See full explanation of issue: https://github.com/colszowka/simplecov/issues/511

For now, lock to earlier version of simplecov.

@codeclimate/review 