### PR TITLE
Allow manual configuration of required git infos

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,22 @@ end
 CodeClimate::TestReporter.start
 ```
 
+### Manual Git Configuration
+
+You can manually provide the required git information if you do not have your git repo available. The
+TestReporter will fallback to commandline git, if you don't provide all information.
+
+```ruby
+CodeClimate::TestReporter.configure do |config|
+  config.git.head = File.read('./GIT_REVISION').strip
+  config.git.committed_at = File.read('./GIT_TIMESTAMP').strip
+  config.git.branch = File.read('./GIT_BRANCH').strip
+end
+```
+
+
+
+
 ## Troubleshooting
 
 If you're having trouble setting up or working with our test coverage feature, [see our detailed help doc](http://docs.codeclimate.com/article/220-help-im-having-trouble-with-test-coverage), which covers the most common issues encountered.

--- a/lib/code_climate/test_reporter/configuration.rb
+++ b/lib/code_climate/test_reporter/configuration.rb
@@ -6,6 +6,7 @@ module CodeClimate
 
     def self.configure
       @@configuration = Configuration.new
+      @@configuration.git = Configuration::Git.new
 
       if block_given?
         yield configuration
@@ -19,7 +20,7 @@ module CodeClimate
     end
 
     class Configuration
-      attr_accessor :branch, :path_prefix, :gzip_request, :git_dir
+      attr_accessor :branch, :path_prefix, :gzip_request, :git_dir, :git
 
       attr_writer :logger, :profile, :timeout
 
@@ -50,6 +51,10 @@ module CodeClimate
         log.level = Logger::INFO
 
         log
+      end
+
+      class Git
+        attr_accessor :branch, :committed_at, :head
       end
     end
   end

--- a/lib/code_climate/test_reporter/git.rb
+++ b/lib/code_climate/test_reporter/git.rb
@@ -4,9 +4,9 @@ module CodeClimate
       class << self
         def info
           {
-            head:         head,
-            committed_at: committed_at,
-            branch:       branch_from_git,
+            head:         configured_git_head || head,
+            committed_at: configured_git_timestamp || committed_at,
+            branch:       configured_git_branch || branch_from_git,
           }
         end
 
@@ -55,6 +55,19 @@ module CodeClimate
         def configured_git_dir
           CodeClimate::TestReporter.configuration.git_dir
         end
+
+        def configured_git_branch
+          CodeClimate::TestReporter.configuration.git.branch
+        end
+
+        def configured_git_timestamp
+          CodeClimate::TestReporter.configuration.git.committed_at
+        end
+
+        def configured_git_head
+          CodeClimate::TestReporter.configuration.git.head
+        end
+
 
         def rails_git_dir_present?
           const_defined?(:Rails) && Rails.respond_to?(:root) && !Rails.root.nil? &&

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -10,6 +10,7 @@ module CodeClimate::TestReporter
 
       it 'provides defaults' do
         expect(CodeClimate::TestReporter.configuration.branch).to be_nil
+        expect(CodeClimate::TestReporter.configuration.git).to be_instance_of Configuration::Git
         expect(CodeClimate::TestReporter.configuration.logger).to be_instance_of Logger
         expect(CodeClimate::TestReporter.configuration.logger.level).to eq Logger::INFO
         expect(CodeClimate::TestReporter.configuration.profile).to eq('test_frameworks')
@@ -69,6 +70,18 @@ module CodeClimate::TestReporter
         end
 
         expect(CodeClimate::TestReporter.configuration.timeout).to eq(666)
+      end
+
+      it 'stored manual git info' do
+        CodeClimate::TestReporter.configure do |config|
+          config.git.head = 'bc6314f05cde7100ecd47d001a1d9f6d7cfd5c96'
+          config.git.committed_at = '1474403999'
+          config.git.branch = 'master'
+        end
+
+        expect(CodeClimate::TestReporter.configuration.git.head).to eq('bc6314f05cde7100ecd47d001a1d9f6d7cfd5c96')
+        expect(CodeClimate::TestReporter.configuration.git.committed_at).to eq('1474403999')
+        expect(CodeClimate::TestReporter.configuration.git.branch).to eq('master')
       end
     end
   end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -72,7 +72,7 @@ module CodeClimate::TestReporter
         expect(CodeClimate::TestReporter.configuration.timeout).to eq(666)
       end
 
-      it 'stored manual git info' do
+      it 'stores manual git info' do
         CodeClimate::TestReporter.configure do |config|
           config.git.head = 'bc6314f05cde7100ecd47d001a1d9f6d7cfd5c96'
           config.git.committed_at = '1474403999'

--- a/spec/lib/git_spec.rb
+++ b/spec/lib/git_spec.rb
@@ -58,6 +58,19 @@ module CodeClimate::TestReporter
       end
     end
 
+    describe 'mixed config/git' do
+      let (:git) { CodeClimate::TestReporter::Configuration::Git.new }
+
+      it 'falls back to git' do
+        git.branch = 'configured'
+        allow(CodeClimate::TestReporter.configuration).to receive(:git).and_return git
+        allow(Git).to receive(:head).and_return '123467890abcdefg'
+
+        expect(Git.info[:branch]).to eq('configured')
+        expect(Git.info[:head]).to eq('123467890abcdefg')
+      end
+    end
+
     describe 'branch_from_git_or_ci' do
       it 'returns the branch from ci' do
         allow(Ci).to receive(:service_data).and_return({branch: 'ci-branch'})


### PR DESCRIPTION
I ran into the same issue as described for the js package - https://github.com/codeclimate/javascript-test-reporter/issues/44. I don't have a local git repo available but have all required information either as ENV vars or as static files. This allows to set the required git information (`head`, `committed_at` and `branch`) manually.