### PR TITLE
Stop sending the test framework

### DIFF
--- a/lib/code_climate/test_reporter/formatter.rb
+++ b/lib/code_climate/test_reporter/formatter.rb
@@ -71,7 +71,6 @@ module CodeClimate
           partial:          partial?,
           git: Git.info,
           environment: {
-            test_framework: result.command_name.downcase,
             pwd:            Dir.pwd,
             rails_root:     (Rails.root.to_s rescue nil),
             simplecov_root: ::SimpleCov.root,

--- a/spec/lib/formatter_spec.rb
+++ b/spec/lib/formatter_spec.rb
@@ -32,7 +32,6 @@ module CodeClimate::TestReporter
           },
         environment:
           {
-            test_framework:  "rspec",
             pwd:  Dir.pwd,
             rails_root:  nil,
             simplecov_root: SimpleCov.root,


### PR DESCRIPTION
It's something that we can no longer infer, now that we're running our
test reporter code separately from the tests themselves.

Or, if we want to infer it, we can't infer it based on the current
process, which is what simplecov will try to do:

https://github.com/colszowka/simplecov/blob/6e5ec2342cc1cfea16ca6c3bb1034062267defbf/lib/simplecov/command_guesser.rb#L43-L56

I don't _think_ that we need to include this, and I'm trying to verify
how we use it.

See https://github.com/codeclimate/ruby-test-reporter/issues/135 for some more context on how this manifests to users.