### PR TITLE
Clarify upgrade instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,26 @@ differences:
 
 * Previously, this gem extended `Simplecov` with a custom formatter which posted
   results to Code Climate. Now, you are responsible for executing `Simplecov`
-  yourself, and then running `codeclimate-test-reporter` as a separate step in
-  your build.
+  yourself.
+
+  * If you already have the following in your test/test_helper.rb
+    (or spec_helper.rb, cucumber env.rb, etc)
+
+    ```ruby
+    require 'codeclimate-test-reporter'
+    CodeClimate::TestReporter.start
+    ```
+
+    then you should replace it with
+
+    ```ruby
+    require 'simplecov'
+    SimpleCov.start
+    ```
+
+* Previously, the `codeclimate-test-reporter` automatically uploaded results at
+  the end of your test suite.  Now, you are responsible for running
+  `codeclimate-test-reporter` as a separate step in your build.
 * Previously, this gem added some exclusion rules tuned according to feedback
   from its users, and now these no longer happen automatically. *If you are
   experiencing a discrepancy in test coverage % after switching to the new gem


### PR DESCRIPTION
I noticed that we need to upgrade some things in our repo, but if you just read the `Upgrading from pre-1.0 Versions` as written, it's hard to tell exactly what needs to change.  It's also easy to miss part of the first bullet because it is technically two separate steps mixed into one bullet.  So as you change the code for the first half, you forget to go back and do the second half.

This clarifies those steps a bit, and separates the first bullet into two separate bullets.