### PR TITLE
Inline the SimpleCov.start to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,14 @@ so if you don't have one the first step is to signup at:
   end
   ```
 
-* Start SimpleCov as you normally would (more information here:
-  https://github.com/colszowka/simplecov)
+* Start [SimpleCov](https://github.com/colszowka/simplecov) right at the top of
+  your `spec/spec_helper.rb`, `test/test_helper.rb`, or cucumber `env.rb`.
+
+  ```ruby
+  require 'simplecov'
+  SimpleCov.start
+  ```
+
 * Set the `CODECLIMATE_REPO_TOKEN` environment variable (provided after you add
   your repo to your Code Climate account by clicking on "Setup Test Coverage" on
   the right hand side of your feed)


### PR DESCRIPTION
The majority of repos won't need to customize beyond this, and for those
who want to, the link is there.