### PR TITLE
Escape SimpleCov.root to allow folders with parens

### DIFF
--- a/lib/code_climate/test_reporter/shorten_filename.rb
+++ b/lib/code_climate/test_reporter/shorten_filename.rb
@@ -7,7 +7,7 @@ module CodeClimate
 
       def short_filename
         return @filename unless ::SimpleCov.root
-        apply_prefix @filename.gsub(/^#{::SimpleCov.root}/, ".").gsub(%r{^\./}, "")
+        apply_prefix @filename.gsub(/^#{Regexp.escape(::SimpleCov.root)}/, ".").gsub(%r{^\./}, "")
       end
 
       private

--- a/spec/lib/shorten_filename_spec.rb
+++ b/spec/lib/shorten_filename_spec.rb
@@ -6,11 +6,25 @@ module CodeClimate::TestReporter
     let(:shorten_filename){ ShortenFilename.new('file1') }
     let(:shorten_filename_with_simplecov_root) { ShortenFilename.new("#{::SimpleCov.root}/file1") }
     let(:shorten_filename_with_double_simplecov_root) { ShortenFilename.new("#{::SimpleCov.root}/#{::SimpleCov.root}/file1") }
+    let(:root) { "/Users/oink/my-great-project" }
+
+    before do
+      allow(::SimpleCov).to receive(:root).and_return(root)
+    end
 
     describe '#short_filename' do
       it 'should return the filename of the file relative to the SimpleCov root' do
-        expect(shorten_filename.send(:short_filename)).to eq('file1')
-        expect(shorten_filename_with_simplecov_root.send(:short_filename)).to eq('file1')
+        expect(shorten_filename.short_filename).to eq('file1')
+        expect(shorten_filename_with_simplecov_root.short_filename).to eq('file1')
+      end
+
+      context "when the root has parentheses in it" do
+        let(:root) { "/Users/oink/my-great-project/hello world (ok)" }
+
+        it 'should return the filename of the file relative to the SimpleCov root' do
+          expect(shorten_filename.short_filename).to eq('file1')
+          expect(shorten_filename_with_simplecov_root.short_filename).to eq('file1')
+        end
       end
 
       context "with path prefix" do
@@ -27,13 +41,13 @@ module CodeClimate::TestReporter
         end
 
         it 'should include the path prefix if set' do
-          expect(shorten_filename.send(:short_filename)).to eq('custom/file1')
-          expect(shorten_filename_with_simplecov_root.send(:short_filename)).to eq('custom/file1')
+          expect(shorten_filename.short_filename).to eq('custom/file1')
+          expect(shorten_filename_with_simplecov_root.short_filename).to eq('custom/file1')
         end
       end
 
       it "should not strip the subdirectory if it has the same name as the root" do
-        expect(shorten_filename_with_double_simplecov_root.send(:short_filename)).to eq("#{::SimpleCov.root}/file1")
+        expect(shorten_filename_with_double_simplecov_root.short_filename).to eq("#{::SimpleCov.root}/file1")
       end
     end
   end


### PR DESCRIPTION
Without escaping the root, the absolute paths remain absolute and then
our validation rejects the test file reports and the user is told their
report is invalid.

This can occur when run in a local environment or on a service such as
Jenkins.

@codeclimate/review 