### PR TITLE
Audit and organize dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .yardoc
 *.DS_Store
 Gemfile.lock
+Gemfile.ruby-19.lock
 InstalledFiles
 _yardoc
 coverage

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,3 @@
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in codeclimate-test-reporter.gemspec
 gemspec
-
-platform :ruby_19 do
-  gem "pry-debugger", group: :development
-end
-
-platform :ruby_21 do
-  gem "pry-byebug", group: :development
-end

--- a/Gemfile.ruby-19
+++ b/Gemfile.ruby-19
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "addressable", "< 2.5"
+gem "json", "~> 1.8", "< 2"
+
+gemspec

--- a/bin/ci
+++ b/bin/ci
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash --login
 
 set -e
 

--- a/bin/ci
+++ b/bin/ci
@@ -1,0 +1,19 @@
+#!/bin/bash --login
+
+set -e
+
+rvm use 1.9.3
+set -x
+ruby -v
+
+bundle install --gemfile Gemfile.ruby-19
+bundle exec rake
+
+set +x
+rvm use 2.2.2
+set -x
+ruby -v
+
+bundle install
+bundle exec rake
+bundle exec bin/codeclimate-test-reporter

--- a/bin/ci
+++ b/bin/ci
@@ -12,4 +12,4 @@ ruby -v
 bundle install
 bundle exec rake
 
-bundle exec bin/codeclimate-test-reporter
+bundle exec codeclimate-test-reporter

--- a/bin/ci
+++ b/bin/ci
@@ -3,12 +3,12 @@
 set -e
 
 rvm use 1.9.3
-test "$(ruby -v)" =~ "1.9.3"
+ruby -v
 bundle install --gemfile Gemfile.ruby-19
 bundle exec rake
 
 rvm use 2.2.2
-test "$(ruby -v)" =~ "2.2.2"
+ruby -v
 bundle install
 bundle exec rake
 

--- a/bin/ci
+++ b/bin/ci
@@ -1,19 +1,15 @@
-#!/bin/bash --login
+#!/bin/bash
 
 set -e
 
 rvm use 1.9.3
-set -x
 ruby -v
-
 bundle install --gemfile Gemfile.ruby-19
 bundle exec rake
 
-set +x
 rvm use 2.2.2
-set -x
 ruby -v
-
 bundle install
 bundle exec rake
+
 bundle exec bin/codeclimate-test-reporter

--- a/bin/ci
+++ b/bin/ci
@@ -3,12 +3,12 @@
 set -e
 
 rvm use 1.9.3
-test "$(ruby -v)" =~ 1.9.3
+test "$(ruby -v)" =~ "1.9.3"
 bundle install --gemfile Gemfile.ruby-19
 bundle exec rake
 
 rvm use 2.2.2
-test "$(ruby -v)" =~ 2.2.2
+test "$(ruby -v)" =~ "2.2.2"
 bundle install
 bundle exec rake
 

--- a/bin/ci
+++ b/bin/ci
@@ -3,12 +3,12 @@
 set -e
 
 rvm use 1.9.3
-ruby -v
+test "$(ruby -v)" =~ 1.9.3
 bundle install --gemfile Gemfile.ruby-19
 bundle exec rake
 
 rvm use 2.2.2
-ruby -v
+test "$(ruby -v)" =~ 2.2.2
 bundle install
 bundle exec rake
 

--- a/circle.yml
+++ b/circle.yml
@@ -3,12 +3,8 @@ dependencies:
     - git config --global user.email "ci@codeclimate.com"
     - git config --global user.name "Code Climate CI"
   override:
-    - rvm 1.9.3 do bundle install
-    - rvm 2.2.2 do bundle install
-
+    - echo "skip"
 
 test:
   override:
-    - rvm 1.9.3 do bundle exec rake
-    - rvm 2.2.2 do bundle exec rake
-    - rvm 2.2.2 do bundle exec bin/codeclimate-test-reporter
+    - bin/ci

--- a/codeclimate-test-reporter.gemspec
+++ b/codeclimate-test-reporter.gemspec
@@ -11,16 +11,14 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
 
   spec.files = `git ls-files bin lib config LICENSE.txt README.md`.split($/)
-  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.executables = ["bin/cc-tddium-post-worker", "bin/codeclimate-test-reporter"]
 
   spec.required_ruby_version = ">= 1.9"
+  spec.add_runtime_dependency "simplecov"
 
-  spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "webmock"
-  spec.add_development_dependency "pry"
-  spec.add_development_dependency "addressable", "< 2.5" if RUBY_VERSION < "2"
-  spec.add_development_dependency "json", "~> 1.8", "< 2" if RUBY_VERSION < "2"
 end

--- a/codeclimate-test-reporter.gemspec
+++ b/codeclimate-test-reporter.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
 
   spec.files = `git ls-files bin lib config LICENSE.txt README.md`.split($/)
-  spec.executables = ["bin/cc-tddium-post-worker", "bin/codeclimate-test-reporter"]
+  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }.reject { |f| f == "ci" }
 
   spec.required_ruby_version = ">= 1.9"
   spec.add_runtime_dependency "simplecov"


### PR DESCRIPTION
* move development dependencies to Gemfile
* use bundler's platform directive to specify ruby version dependency
  differences
* promote SimpleCov to a runtime depenency

Inspired by:

* https://github.com/codeclimate/ruby-test-reporter/commit/a0e5d038dfbcaed56e5b7b2b30a7ec2ab1c468db#commitcomment-19735625
* https://github.com/codeclimate/ruby-test-reporter/issues/146#issuecomment-259260662

@codeclimate/review @dblandin 