### PR TITLE
Pass thru Travis PR SHA

### DIFF
--- a/lib/code_climate/test_reporter/ci.rb
+++ b/lib/code_climate/test_reporter/ci.rb
@@ -4,12 +4,16 @@ module CodeClimate
 
       def self.service_data(env = ENV)
         if env["TRAVIS"]
+          travis_extras = {}
+          if env["TRAVIS_PULL_REQUEST_SHA"] != ""
+            travis_extras[:commit_sha] = env["TRAVIS_PULL_REQUEST_SHA"]
+          end
           {
             name:             "travis-ci",
             branch:           env["TRAVIS_BRANCH"],
             build_identifier: env["TRAVIS_JOB_ID"],
             pull_request:     env["TRAVIS_PULL_REQUEST"]
-          }
+          }.merge(travis_extras)
         elsif env["CIRCLECI"]
           {
             name:             "circleci",


### PR DESCRIPTION
When Travis builds a PR, as opposed to a push, it checks out the merge
commit that GitHub exposes and runs the tests at that SHA.

When we report the results, however, we'd like to report them for the
HEAD SHA from the PR, because otherwise the status won't show up.

it's possible the coverage results will differ slightly between the
merge SHA and the HEAD sha, but I'm not sure if anyone will be offended
by this fiction. We've had one report that a user is surprised not to
receive a status check when they only have Pull Request builds enabled,
and not Push builds.

:warning: This is slightly WIP, as I do some testing on a test repo to confirm it works