### PR TITLE
Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,71 @@
+# Change log
+
+## master (unreleased)
+
+### New features
+
+### Bug fixes
+
+### Changes
+
+## v1.0.3 (2016-11-09)
+
+### Bug fixes
+
+* Improve strategy for Ruby 1.9.3 compatibility testing
+
+## v1.0.2 (2016-11-08)
+
+### Bug fixes
+
+* Fixed crashing error when the path to a file in the coverage report
+  contains a parenthesis.
+
+## v1.0.1 (2016-11-06)
+
+### Bug fixes
+
+* Made sure the gem can be built while running Ruby 1.9.3
+
+## v1.0.0 (2016-11-03)
+
+### Changes
+
+* Previously, this gem extended `Simplecov` with a custom formatter which posted
+  results to Code Climate. Now, you are responsible for executing `Simplecov`
+  yourself.
+
+  * If you already have the following in your test/test_helper.rb
+    (or spec_helper.rb, cucumber env.rb, etc)
+
+    ```ruby
+    require 'codeclimate-test-reporter'
+    CodeClimate::TestReporter.start
+    ```
+
+    then you should replace it with
+
+    ```ruby
+    require 'simplecov'
+    SimpleCov.start
+    ```
+
+* Previously, the `codeclimate-test-reporter` automatically uploaded results at
+  the end of your test suite.  Now, you are responsible for running
+  `codeclimate-test-reporter` as a separate step in your build.
+* Previously, this gem added some exclusion rules tuned according to feedback
+  from its users, and now these no longer happen automatically. *If you are
+  experiencing a discrepancy in test coverage % after switching to the new gem
+  version, it may be due to missing exclusions. Filtering `vendor`, `spec`, or
+  `test` directories may fix this issue.*
+* Previously, during the execution of multiple test suites, this gem would send
+  results from the first suite completed. You are now expected to run an
+  executable packaged with this gem as a separate build step, which means that
+  whatever results are there (likely the results from the last suite) will be
+  posted to Code Climate.
+
+## v0.6.0 (2016-06-27)
+
+### New features
+
+* Support `ENV["SSL_CERT_PATH"]` for custom SSL certificates

--- a/README.md
+++ b/README.md
@@ -25,42 +25,11 @@ documentation here: https://docs.codeclimate.com/docs/setting-up-test-coverage
 
 ## Upgrading from pre-1.0 Versions
 
-Version `1.0` of the this gem introduces new, breaking changes to the way the
+Version `1.0` of this gem introduced new, breaking changes to the way the
 test reporter is meant to be executed. The following list summarizes the major
 differences:
 
-* Previously, this gem extended `Simplecov` with a custom formatter which posted
-  results to Code Climate. Now, you are responsible for executing `Simplecov`
-  yourself.
-
-  * If you already have the following in your test/test_helper.rb
-    (or spec_helper.rb, cucumber env.rb, etc)
-
-    ```ruby
-    require 'codeclimate-test-reporter'
-    CodeClimate::TestReporter.start
-    ```
-
-    then you should replace it with
-
-    ```ruby
-    require 'simplecov'
-    SimpleCov.start
-    ```
-
-* Previously, the `codeclimate-test-reporter` automatically uploaded results at
-  the end of your test suite.  Now, you are responsible for running
-  `codeclimate-test-reporter` as a separate step in your build.
-* Previously, this gem added some exclusion rules tuned according to feedback
-  from its users, and now these no longer happen automatically. *If you are
-  experiencing a discrepancy in test coverage % after switching to the new gem
-  version, it may be due to missing exclusions. Filtering `vendor`, `spec`, or
-  `test` directories may fix this issue.*
-* Previously, during the execution of multiple test suites, this gem would send
-  results from the first suite completed. You are now expected to run an
-  executable packaged with this gem as a separate build step, which means that
-  whatever results are there (likely the results from the last suite) will be
-  posted to Code Climate.
+See [the changelog entry for v1.0.0](CHANGELOG.md#v100-2016-11-03) for details.
 
 ## Contributions
 
@@ -68,7 +37,21 @@ Patches, bug fixes, feature requests, and pull requests are welcome on the
 GitHub page for this project:
 [https://github.com/codeclimate/ruby-test-reporter](https://github.com/codeclimate/ruby-test-reporter)
 
+When making a pull request, please update the [changelog](CHANGELOG.md).
+
 This gem is maintained by Code Climate (hello@codeclimate.com).
+
+### Release Process
+
+* Update the changelog to mark the unreleased changes as part of the new release.
+* Update the version.rb with the new version number
+* Make a pull request with those changes
+* Merge those changes to master
+* Check out and pull down the latest master locally
+* `rake release` which will
+  * tag the latest commit based on version.rb
+  * push to github
+  * push to rubygems
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Patches, bug fixes, feature requests, and pull requests are welcome on the
 GitHub page for this project:
 [https://github.com/codeclimate/ruby-test-reporter](https://github.com/codeclimate/ruby-test-reporter)
 
-This gem is maintained by Bryan Helmkamp (bryan@codeclimate.com).
+This gem is maintained by Code Climate (hello@codeclimate.com).
 
 ## Copyright
 

--- a/codeclimate-test-reporter.gemspec
+++ b/codeclimate-test-reporter.gemspec
@@ -3,8 +3,8 @@ require "./lib/code_climate/test_reporter/version"
 Gem::Specification.new do |spec|
   spec.name = "codeclimate-test-reporter"
   spec.version = CodeClimate::TestReporter::VERSION
-  spec.authors = ["Bryan Helmkamp"]
-  spec.email = ["bryan@brynary.com"]
+  spec.authors = ["Bryan Helmkamp", "Code Climate"]
+  spec.email = ["bryan@brynary.com", "hello@codeclimate.com"]
   spec.description = "Collects test coverage data from your Ruby test suite and sends it to Code Climate's hosted, automated code review service. Based on SimpleCov."
   spec.summary = "Uploads Ruby test coverage data to Code Climate."
   spec.homepage = "https://github.com/codeclimate/ruby-test-reporter"


### PR DESCRIPTION
Also updated the release process (mostly copied from minidoc) to
emphasize the importance of updating the changelog

Moved the 1.0.0 upgrade instructions into the changelog. Left the
section, because we linked to it in some places, and I don't want to
break those links.

Didn't document the changelog going back all the way to the beginning.
We could fill that in, but I don't think it's urgent.

Close #152 