### PR TITLE
Fix build for ruby 1.9

### DIFF
--- a/Gemfile.ruby-19
+++ b/Gemfile.ruby-19
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "addressable", "< 2.5"
 gem "json", "~> 1.8", "< 2"
+gem "webmock", "< 2.3.1"
 
 gemspec


### PR DESCRIPTION
The newer webmock doesn't allow using with Ruby 1.9.3