### PR TITLE
Add execution example and mention optional env

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ instructions on our [documentation site](https://docs.codeclimate.com/docs/ruby)
 
 Please contact hello@codeclimate.com if you need any assistance setting this up.
 
+## Usage
+
+```
+CODECLIMATE_REPO_TOKEN=my_token bundle exec rspec && bundle exec codeclimate-test-reporter
+```
+
+**Optional**: configure `CODECLIMATE_API_HOST` to point to a self-hosted version of Code Climate.
+
 ## Troubleshooting / FYIs
 
 Across the many different testing frameworks, setups, and environments, there


### PR DESCRIPTION
Thought this usage section would be useful to have. We don't mention the env var anywhere in README or our docs.