### PR TITLE
Lock simplecov between 0.10 and 0.13 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Bug fixes
 
+* Lock simplecov to `<= 0.13`, so we can safely use an internal-to-simplecov
+  method.
+  ([@bliof](https://github.com/codeclimate/ruby-test-reporter/pull/181))
+
 ### Changes
 
 ### v1.0.7 (2017-03-08)

--- a/codeclimate-test-reporter.gemspec
+++ b/codeclimate-test-reporter.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }.reject { |f| f == "ci" }
 
   spec.required_ruby_version = ">= 1.9"
-  spec.add_runtime_dependency "simplecov"
+  spec.add_runtime_dependency "simplecov", ">= 0.10", "<= 0.13"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "pry"

--- a/codeclimate-test-reporter.gemspec
+++ b/codeclimate-test-reporter.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }.reject { |f| f == "ci" }
 
   spec.required_ruby_version = ">= 1.9"
-  spec.add_runtime_dependency "simplecov", ">= 0.10", "<= 0.13"
+  spec.add_runtime_dependency "simplecov", "<= 0.13"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "pry"

--- a/lib/code_climate/test_reporter/version.rb
+++ b/lib/code_climate/test_reporter/version.rb
@@ -1,5 +1,5 @@
 module CodeClimate
   module TestReporter
-    VERSION = "1.0.7".freeze
+    VERSION = "1.0.8".freeze
   end
 end

--- a/lib/code_climate/test_reporter/version.rb
+++ b/lib/code_climate/test_reporter/version.rb
@@ -1,5 +1,5 @@
 module CodeClimate
   module TestReporter
-    VERSION = "1.0.8".freeze
+    VERSION = "1.0.7".freeze
   end
 end


### PR DESCRIPTION
Done because the 0.14.0 version introduces some changes that break the
`CodeClimate::TestReporter::Formatter#merge_results`
https://github.com/colszowka/simplecov/commit/a7747c1391b7f8d0b7081c23df79b151ebbc95bd

Check also:
  * SimpleCov::Result - https://github.com/colszowka/simplecov/blob/v0.14.0/lib/simplecov/result.rb
  * SimpleCov::RawCoverage - https://github.com/colszowka/simplecov/blob/v0.14.0/lib/simplecov/raw_coverage.rb