### PR TITLE
Update usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Please contact hello@codeclimate.com if you need any assistance setting this up.
 
 ## Usage
 
-```
-CODECLIMATE_REPO_TOKEN=my_token bundle exec rspec && bundle exec codeclimate-test-reporter
+```console
+bundle exec rspec && CODECLIMATE_REPO_TOKEN=my_token bundle exec codeclimate-test-reporter
 ```
 
 **Optional**: configure `CODECLIMATE_API_HOST` to point to a self-hosted version of Code Climate.


### PR DESCRIPTION
Addresses #184

Inline environment variables are only visible to the command they immediately precede. We only require the token while submitting test coverage so this commit moves the token to precede the `codeclimate-test-reporter` invocation.