### PR TITLE
Fall back to current time if git metadata is not available

### DIFF
--- a/lib/code_climate/test_reporter/git.rb
+++ b/lib/code_climate/test_reporter/git.rb
@@ -19,7 +19,7 @@ module CodeClimate
         end
 
         def committed_at_from_git_or_ci
-          committed_at_from_git || committed_at_from_ci
+          committed_at_from_git || committed_at_from_ci || Time.now.to_i
         end
 
         def clean_service_branch

--- a/spec/code_climate/test_reporter/git_spec.rb
+++ b/spec/code_climate/test_reporter/git_spec.rb
@@ -110,7 +110,7 @@ module CodeClimate::TestReporter
         expect(Git).to receive(:committed_at_from_git).and_return(nil)
         allow(Ci).to receive(:service_data).and_return({})
 
-        expect(Git.committed_at_from_git_or_ci).to be_nil
+        expect(Git.committed_at_from_git_or_ci).to be_a Numeric
       end
     end
 


### PR DESCRIPTION
This change makes coverage reporting work from a Docker container built in CI with no `git` metadata (as this is not something you want persisted in your Docker image). I believe that current timestamp is a decent fallback value, since you'd usually run coverage reporter from a CI provider which is triggered by a commit. An alternative I think would be to allow passing commit timestamp as an environment variable.