### PR TITLE
Add support for open-sourced DroneCI

### DIFF
--- a/lib/code_climate/test_reporter/ci.rb
+++ b/lib/code_climate/test_reporter/ci.rb
@@ -62,6 +62,17 @@ module CodeClimate
             commit_sha:       env["CI_COMMIT"],
             pull_request:     env["CI_PULL_REQUEST"],
           }
+        elsif env["DRONE"]
+          # open-sourced DroneCI uses a different set of env vars
+          # http://readme.drone.io/usage/environment-reference/
+          {
+            name:             "drone",
+            build_identifier: env["DRONE_BUILD_NUMBER"],
+            build_url:        env["DRONE_BUILD_LINK"],
+            branch:           env["DRONE_BRANCH"],
+            commit_sha:       env["DRONE_COMMIT"],
+            pull_request:     env["DRONE_PULL_REQUEST"],
+          }
         elsif env["CI_NAME"] =~ /codeship/i
           {
             name:             "codeship",


### PR DESCRIPTION
Open-sourced DroneCI uses a different set of environment variables:
http://readme.drone.io/usage/environment-reference/

This PR adds open-sourced DroneCI support.

We're using a self-hosted DroneCI, and just tested this PR. So far it's working.

Note: Before submit this PR, we also contacted CodeClimate Support. I think our support ticket is still opened, in case you need more context of this PR. 🙏 